### PR TITLE
Fixed bug introduced by change in bosh/bosh-stemcell

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -102,7 +102,7 @@ jobs:
       params:
         BOSH_AWS_ACCESS_KEY_ID: {{BOSH_AWS_ACCESS_KEY_ID}}
         BOSH_AWS_SECRET_ACCESS_KEY: {{BOSH_AWS_SECRET_ACCESS_KEY}}
-        BOSH_KEY_PATH: ../../bosh-softlayer-private/bosh.pem
+        BOSH_VAGRANT_KEY_PATH: ../../bosh-softlayer-private/bosh.pem
         AWS_ACCESS_KEY: {{BOSH_AWS_ACCESS_KEY_ID}}
         AWS_SECRET_KEY: {{BOSH_AWS_SECRET_ACCESS_KEY}}
         S3_ACCESS_KEY: {{s3-access-key-id}}


### PR DESCRIPTION
cloudfoundry/bosh@e0ef893073e835c62ec7c5586ef1dda621ebc7ac

The commit tagged above changes the env variable used to point to the private key in bosh-stemcell, which is why bosh-stemcell has been failing.

This PR is just renaming it in concourse to fix that.
